### PR TITLE
Use option write_concurrency

### DIFF
--- a/src/seshat_counters.erl
+++ b/src/seshat_counters.erl
@@ -31,7 +31,7 @@ delete_group(Group) ->
                  counters:counters_ref().
 new(Group, Name, Fields) when is_list(Fields) ->
     Size = length(Fields),
-    CRef = counters:new(Size, []),
+    CRef = counters:new(Size, [write_concurrency]),
     ok = register_counter(Group, Name, CRef, Fields),
     CRef.
 


### PR DESCRIPTION
Our use case fits that option very well because:

* The channel processes and stream reader connection processes write concurrently.
* The writes are very frequent compared to reading via seshat_counters:prometheus_format/1 and seshat_counters:overview/1.
* We don't require "absolute read consistency".

See docs in http://erlang.org/doc/man/counters.html.
This is a follow up of https://github.com/rabbitmq/rabbitmq-server/pull/3127#pullrequestreview-689223989.