### PR TITLE
Save memory when fetching CounterRef

### DIFF
--- a/src/seshat.erl
+++ b/src/seshat.erl
@@ -57,13 +57,16 @@ new(Group, Name, Fields) when is_list(Fields) ->
             error(invalid_field_specification)
     end.
 
+%% fetch/2 is NOT meant to be called for every counter update.
+%% Instead, for higher performance, the consuming application should store the returned counters_ref
+%% in a stateful Erlang module or in persistent_term (see persistent:term_put/2).
 -spec fetch(group(), name()) -> undefined | counters:counters_ref().
 fetch(Group, Name) ->
     TRef = seshat_counters_server:get_table(Group),
-    case ets:lookup(TRef, Name) of
-        [{Name, Ref, _}] ->
-            Ref;
-        _ ->
+    try
+        ets:lookup_element(TRef, Name, 2)
+    catch
+        error:badarg ->
             undefined
     end.
 


### PR DESCRIPTION
Prior to this commit, the whole record gets copied from ETS table to
process memory.

This can be huge depending on the counters stored.
Taking as example a counter from module rabbit_global_counters:
```
erts_debug:size(ets:lookup(#Ref<0.3918382698.2273343841.126254>, [{protocol,stream}])).
3126
```
3126 words * 8 bytes = 25KB

This commits protects an application from misusing the library by
frequently calling `seshat:fetch/2` instead of storing the CounterRef itself in a
stateful Erlang module or in peristent_term.