### PR TITLE
Add seshat:counters/3 to only return counters for requested fields.

### DIFF
--- a/src/seshat.erl
+++ b/src/seshat.erl
@@ -13,6 +13,7 @@
          fetch/2,
          overview/1,
          overview/2,
+         counters/3,
          delete/2,
          format/1
         ]).
@@ -95,6 +96,23 @@ overview(Group, Name) ->
         [{Name, Ref, Fields}] ->
             lists:foldl(fun ({Key, Index, _Type, _Description}, Acc0) ->
                                 Acc0#{Key => counters:get(Ref, Index)}
+                        end, #{}, Fields);
+        _ ->
+            undefined
+    end.
+
+-spec counters(group(), name(), [atom()]) ->
+    #{atom() => integer()} | undefined.
+counters(Group, Name, FieldNames) ->
+    case ets:lookup(seshat_counters_server:get_table(Group), Name) of
+        [{Name, Ref, Fields}] ->
+            lists:foldl(fun ({Key, Index, _Type, _Description}, Acc0) ->
+                                case lists:member(Key, FieldNames) of
+                                    true ->
+                                        Acc0#{Key => counters:get(Ref, Index)};
+                                    false ->
+                                        Acc0
+                                end
                         end, #{}, Fields);
         _ ->
             undefined

--- a/test/seshat_test.erl
+++ b/test/seshat_test.erl
@@ -48,6 +48,9 @@ overview() ->
     ?assertMatch(#{carrots_eaten_total := 3,
                    holes_dug_total := 1},
                  seshat:overview(Group, "rabbit")),
+
+    ?assertMatch(#{holes_dug_total := 1},
+                 seshat:counters(Group, "rabbit", [holes_dug_total])),
     ok.
 
 prometheus_format_multiple_names() ->


### PR DESCRIPTION
This should avoid building up unnecessarily large maps if only a small subset of fields are required.