### PR TITLE
Optimise seshat:counters/3

### DIFF
--- a/src/seshat.erl
+++ b/src/seshat.erl
@@ -123,11 +123,18 @@ build_counters_map(CRef, FieldsSpec, all) ->
     lists:foldl(fun ({Name, Index, _Type, _Help}, Acc0) ->
                         Acc0#{Name => counters:get(CRef, Index)}
                 end, #{}, Fields);
+build_counters_map(CRef, FieldsSpec, [Name]) ->
+    %% Optimized path for single name lookup
+    Fields = resolve_fields_spec(FieldsSpec),
+    case lists:keyfind(Name, 1, Fields) of
+        {Name, Index, _Type, _Help} ->
+            #{Name => counters:get(CRef, Index)};
+        false ->
+            #{}
+    end;
 build_counters_map(CRef, FieldsSpec, Names) when is_list(Names) ->
     Fields = resolve_fields_spec(FieldsSpec),
     lists:foldl(fun ({Name, Index, _Type, _Help}, Acc0) ->
-                        % the assumption here is that Names is a very
-                        % short list likely of just 1 element
                         case lists:member(Name, Names) of
                             true ->
                                 Acc0#{Name => counters:get(CRef, Index)};


### PR DESCRIPTION
If someone uses this function, the list of counters to return is likely very short, quite possibly it has 1 element. Rather than building a map of all counters and then dropping the irrelevant ones, only add the relevant counters in the first place.

Testing with RabbitMQ an rabbit_quorum_queue:open_files function, which only asks for 1 metric, the avery execution went down form 7ms to 1ms with this change.